### PR TITLE
Config file is not found if it is called "config"

### DIFF
--- a/kasapi.sh
+++ b/kasapi.sh
@@ -31,7 +31,7 @@ _exiterr() {
 }
 
 # Get config
-if [[ -f "${SCRIPTDIR}/config." ]]; then
+if [[ -f "${SCRIPTDIR}/config" ]]; then
 	. "${SCRIPTDIR}/config"
 elif [[ -f "${SCRIPTDIR}/config.sh" ]]; then
 	. "${SCRIPTDIR}/config.sh"


### PR DESCRIPTION
If I call the config file "config" like the manual suggests, then it is not found. This is as far as I can see because of a broken comparison when checking whether the file exists.